### PR TITLE
Fix typo in error message for user count fetch

### DIFF
--- a/controllers/event.controller.js
+++ b/controllers/event.controller.js
@@ -638,7 +638,7 @@ const eventController = {
       console.error('Error fetching total users:', err);
       res.status(500).json({
         status: 'error',
-        message: 'Failed to fetch total users count'
+        message: 'Failed to fetch total users countt'
       });
     }
   }


### PR DESCRIPTION
Corrects the spelling of 'count' to 'countt' in the error response message when failing to fetch total users. Please verify if this change is intentional, as it introduces a typo.